### PR TITLE
:clap: change progress spinner on create user

### DIFF
--- a/app/src/main/java/com/blueharvest/geocaching/create_user.java
+++ b/app/src/main/java/com/blueharvest/geocaching/create_user.java
@@ -312,7 +312,7 @@ public class create_user extends AppCompatActivity {
         else {
             // Show a progress spinner, and kick off a background task to
             // perform the user login attempt.
-            //showProgress(true);
+            showProgress(true); // jmb: uncommented out ... not sure why it was in the first place
             mCreateTask = new UserCreateTask();
             mCreateTask.execute((Void) null);
         }

--- a/app/src/main/res/layout/activity_create_user.xml
+++ b/app/src/main/res/layout/activity_create_user.xml
@@ -19,7 +19,8 @@
             style="?android:attr/progressBarStyleLarge"
             android:layout_width="11dp"
             android:layout_height="11dp"
-            android:id="@+id/create_user_progress" />
+            android:id="@+id/create_user_progress"
+            android:visibility="gone"/>
 
         <EditText
             android:layout_width="match_parent"


### PR DESCRIPTION
the progress spinner was showing from the start of the activity rather than when the create task was called; the visibility was changed in the layout xml and the show method uncommented in the java.
